### PR TITLE
Bitstream Edit

### DIFF
--- a/metadata-aardvark/Other/nyu-2451-34051.json
+++ b/metadata-aardvark/Other/nyu-2451-34051.json
@@ -25,7 +25,7 @@
     "ESRI 10 StreetMap"
   ],
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34051\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/bitstream/2451/34051/4/nyu_2451_34051.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34051\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/bitstream/2451/34051/2/nyu-2010USCanadaHighwayExits.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\"}",
   "dct_spatial_sm": [
     "United States of America",
     "Canada"


### PR DESCRIPTION
The record points to https://archive.nyu.edu/bitstream/2451/34051/4/nyu_2451_34051.zip

However, the correct URL is https://archive.nyu.edu/bitstream/2451/34051/2/nyu-2010USCanadaHighwayExits.zip