### PR TITLE
dct_issued_s and dct_references_s should be strings

### DIFF
--- a/metadata-aardvark/Datasets/nyu-2451-34407.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34407.json
@@ -29,15 +29,9 @@
   "dct_isPartOf_sm": [
     "PollMap of India"
   ],
-  "dct_issued_s": 2013,
+  "dct_issued_s": "2013",
   "schema_provider_s": "NYU",
-  "dct_references_s": {
-    "http://schema.org/url": "http://hdl.handle.net/2451/34407",
-    "http://www.opengis.net/def/serviceType/ogc/wfs": "https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs",
-    "http://www.opengis.net/def/serviceType/ogc/wms": "https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms",
-    "http://schema.org/downloadUrl": "https://archive.nyu.edu/retrieve/73392/nyu_2451_34407.zip",
-    "http://lccn.loc.gov/sh85035852": "https://archive.nyu.edu/retrieve/78658/nyu_2451_34407_doc.zip"
-  },
+  "dct_references_s": "{\"http://schema.org/url\": \"http://hdl.handle.net/2451/34407\", \"http://www.opengis.net/def/serviceType/ogc/wfs\": \"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\", \"http://www.opengis.net/def/serviceType/ogc/wms\": \"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\", \"http://schema.org/downloadUrl\": \"https://archive.nyu.edu/retrieve/73392/nyu_2451_34407.zip\", \"http://lccn.loc.gov/sh85035852\": \"https://archive.nyu.edu/retrieve/78658/nyu_2451_34407_doc.zip\"}",
   "dct_spatial_sm": [
     "Tripura, India",
     "Belonia, Tripura, India",

--- a/metadata-aardvark/Datasets/nyu-2451-60171.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60171.json
@@ -60,5 +60,5 @@
   "gbl_indexYear_im": [
     2014
   ],
-  "dct_issued_s": 2015
+  "dct_issued_s": "2015"
 }

--- a/metadata-aardvark/Datasets/nyu-2451-60174.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60174.json
@@ -59,5 +59,5 @@
   "gbl_indexYear_im": [
     2018
   ],
-  "dct_issued_s": 2019
+  "dct_issued_s": "2019"
 }

--- a/metadata-aardvark/Datasets/nyu-2451-60181.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60181.json
@@ -56,5 +56,5 @@
   "gbl_indexYear_im": [
     2013
   ],
-  "dct_issued_s": 2014
+  "dct_issued_s": "2014"
 }

--- a/metadata-aardvark/Datasets/nyu-2451-60182.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60182.json
@@ -56,5 +56,5 @@
   "gbl_indexYear_im": [
     2018
   ],
-  "dct_issued_s": 2019
+  "dct_issued_s": "2019"
 }


### PR DESCRIPTION
While setting up this repo to make some other fixes I noticed that the linter was failing due to some formatting errors. This PR fixes those errors.

- some `dct_issued_s`'s were using integers instead of strings
- one `dct_references_s` was using a JSON object instead of a string of JSON