### PR TITLE
Fix records using an underscore instead of colon for layer IDs

### DIFF
--- a/metadata-1.0/handle/2451/6/00/73/geoblacklight.json
+++ b/metadata-1.0/handle/2451/6/00/73/geoblacklight.json
@@ -35,7 +35,7 @@
   ],
   "geoblacklight_version": "1.0",
   "layer_geom_type_s": "Raster",
-  "layer_id_s": "sdr_nyu_2451_60073",
+  "layer_id_s": "sdr:nyu_2451_60073",
   "layer_modified_dt": "2020-07-21T09:42:33Z",
   "layer_slug_s": "nyu-2451-60073",
   "nyu_addl_license_s": "Attribution 4.0 International (CC BY 4.0)",

--- a/metadata-1.0/handle/2451/6/00/74/geoblacklight.json
+++ b/metadata-1.0/handle/2451/6/00/74/geoblacklight.json
@@ -36,7 +36,7 @@
   ],
   "geoblacklight_version": "1.0",
   "layer_geom_type_s": "Raster",
-  "layer_id_s": "sdr_nyu_2451_60074",
+  "layer_id_s": "sdr:nyu_2451_60074",
   "layer_modified_dt": "2020-07-21T09:42:33Z",
   "layer_slug_s": "nyu-2451-60074",
   "nyu_addl_license_s": "Attribution 4.0 International (CC BY 4.0)",

--- a/metadata-aardvark/Datasets/nyu-2451-60073.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60073.json
@@ -45,7 +45,7 @@
   "gbl_resourceType_sm": [
     "Raster data"
   ],
-  "gbl_wxsIdentifier_s": "sdr_nyu_2451_60073",
+  "gbl_wxsIdentifier_s": "sdr:nyu_2451_60073",
   "gbl_mdModified_dt": "2020-07-21T09:42:33Z",
   "id": "nyu-2451-60073",
   "nyu_addl_license_s": "Attribution 4.0 International (CC BY 4.0)",

--- a/metadata-aardvark/Datasets/nyu-2451-60074.json
+++ b/metadata-aardvark/Datasets/nyu-2451-60074.json
@@ -48,7 +48,7 @@
   "gbl_resourceType_sm": [
     "Raster data"
   ],
-  "gbl_wxsIdentifier_s": "sdr_nyu_2451_60074",
+  "gbl_wxsIdentifier_s": "sdr:nyu_2451_60074",
   "gbl_mdModified_dt": "2020-07-21T09:42:33Z",
   "id": "nyu-2451-60074",
   "nyu_addl_license_s": "Attribution 4.0 International (CC BY 4.0)",


### PR DESCRIPTION
There are a couple of records that have `sdr_nyu` instead of `sdr:nyu` for their layer/wxs IDs. This PR fixes those entries.