### PR TITLE
GeoServer does not support ESRI Geodatabases

### DIFF
--- a/metadata-aardvark/Datasets/nyu-2451-34912.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34912.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34912\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124064/nyu_2451_34912.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124025/nyu_2451_34912_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34912\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124064/nyu_2451_34912.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124025/nyu_2451_34912_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Argentina"

--- a/metadata-aardvark/Datasets/nyu-2451-34915.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34915.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34915\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124065/nyu_2451_34915.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124424/nyu_2451_34915_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34915\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124065/nyu_2451_34915.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124424/nyu_2451_34915_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Colombia"

--- a/metadata-aardvark/Datasets/nyu-2451-34917.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34917.json
@@ -25,7 +25,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34917\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124052/nyu_2451_34917.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/bitstream/2451/34917/3/nyu_2451_34917_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34917\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124052/nyu_2451_34917.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/bitstream/2451/34917/3/nyu_2451_34917_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Ecuador"

--- a/metadata-aardvark/Datasets/nyu-2451-34918.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34918.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34918\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124114/nyu_2451_34918.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124115/nyu_2451_34918_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34918\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124114/nyu_2451_34918.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124115/nyu_2451_34918_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Panama"
@@ -43,7 +43,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34918",
   "gbl_mdModified_dt": "2020-07-21T13:25:26Z",
   "id": "nyu-2451-34918",
   "nyu_addl_dspace_s": "35884",

--- a/metadata-aardvark/Datasets/nyu-2451-34919.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34919.json
@@ -1,6 +1,5 @@
 {
   "id": "nyu-2451-34919",
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34919",
   "schema_provider_s": "NYU",
   "gbl_resourceClass_sm": [
     "Datasets"
@@ -38,7 +37,7 @@
   "gbl_mdModified_dt": "2020-04-27T10:20:09Z",
   "nyu_addl_dspace_s": "35885",
   "gbl_mdVersion_s": "Aardvark",
-  "dct_references_s": "{\"http://schema.org/url\": \"http://hdl.handle.net/2451/34919\",\n  \"http://schema.org/downloadUrl\": \"https://archive.nyu.edu/retrieve/124066/nyu_2451_34919.zip\",\n  \"http://www.opengis.net/def/serviceType/ogc/wfs\": \"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\n  \"http://www.opengis.net/def/serviceType/ogc/wms\": \"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\n\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/123844/nyu_2451_34919_doc.zip\"}\n",
+  "dct_references_s": "{\"http://schema.org/url\": \"http://hdl.handle.net/2451/34919\",\"http://schema.org/downloadUrl\": \"https://archive.nyu.edu/retrieve/124066/nyu_2451_34919.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/123844/nyu_2451_34919_doc.zip\"}",
   "dct_description_sm": [
     "This geodatabase contains basic population, economic, and housing characteristics for districts in Costa Rica, collected as part of its Censo 2011 by the Instituto Nacional de Estadística y Censos. The data was documented and restructured by East View Cartographic, Inc. The census data is provided at the district administrative level (ADM3) and includes 472 polygons with 719 attribute variables, split into 5 tables. Attribute descriptions retain original language names and unique identifier codes. All variable names were translated from Spanish. Field name prefixes, originally written with coded titles, were renamed to create unique names (e.g. Original variable of “Estado Civil: Unión Libre o Juntadoa” was updated to D001 and given the alias “Marital Status: Free Union[Estado Civil: Unión Libre o Juntadoa]”, the letter D was given as it relates to the Demographic theme table. D = Demographic, E = Economic, H = Housing, M = Migration and S = Social). All variables from the original data were reviewed for completeness and organized into their relevant themes of Demographic, Economic, Housing, Migration and Social. In attribute tables, all geographic names and codes are represented as text fields and census data are represented as doubles or long integers. Automated tools were run to apply aliases in the format “English translation field description[original language field description]”. Vector data was analyzed for accuracy and compared with national boundaries. This geodatabase is part of a partnership project with East View Cartographic and IPUMS International, titled the Global Census Archive. Refer to the metadata and documentation for original and translated codebooks and methodology."
   ],

--- a/metadata-aardvark/Datasets/nyu-2451-34920.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34920.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34920\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/bitstream/2451/34920/2/nyu_2451_34920.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/bitstream/2451/34920/3/nyu_2451_34920_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34920\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/bitstream/2451/34920/2/nyu_2451_34920.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/bitstream/2451/34920/3/nyu_2451_34920_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Peru"
@@ -43,7 +43,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34920",
   "gbl_mdModified_dt": "2020-07-21T13:25:26Z",
   "id": "nyu-2451-34920",
   "nyu_addl_dspace_s": "35886",

--- a/metadata-aardvark/Datasets/nyu-2451-34921.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34921.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34921\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124078/nyu_2451_34921.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124077/nyu_2451_34921_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34921\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124078/nyu_2451_34921.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124077/nyu_2451_34921_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Dominican Republic"
@@ -43,7 +43,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34921",
   "gbl_mdModified_dt": "2020-08-20T14:10:31Z",
   "id": "nyu-2451-34921",
   "nyu_addl_dspace_s": "35887",

--- a/metadata-aardvark/Datasets/nyu-2451-34922.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34922.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34922\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124097/nyu_2451_34922.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124098/nyu_2451_34922_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34922\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124097/nyu_2451_34922.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124098/nyu_2451_34922_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Guatemala"
@@ -43,7 +43,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34922",
   "gbl_mdModified_dt": "2020-07-21T13:25:26Z",
   "id": "nyu-2451-34922",
   "nyu_addl_dspace_s": "35888",

--- a/metadata-aardvark/Datasets/nyu-2451-34924.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34924.json
@@ -31,7 +31,7 @@
   ],
   "dct_issued_s": "2016",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34924\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124099/nyu_2451_34924.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124100/nyu_2451_34924_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34924\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/124099/nyu_2451_34924.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/124100/nyu_2451_34924_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Honduras"

--- a/metadata-aardvark/Datasets/nyu-2451-42186.json
+++ b/metadata-aardvark/Datasets/nyu-2451-42186.json
@@ -28,7 +28,7 @@
   ],
   "dct_issued_s": "3/12/2018",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42186\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85098/nyu_2451_42186.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42186\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85098/nyu_2451_42186.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Arunachal Pradesh, India"
@@ -40,7 +40,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_42186",
   "gbl_mdModified_dt": "2018-06-19T16:03:45Z",
   "id": "nyu-2451-42186",
   "nyu_addl_dspace_s": "43290",

--- a/metadata-aardvark/Datasets/nyu-2451-42199.json
+++ b/metadata-aardvark/Datasets/nyu-2451-42199.json
@@ -28,7 +28,7 @@
   ],
   "dct_issued_s": "3/12/2018",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42199\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85097/nyu_2451_42199.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42199\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85097/nyu_2451_42199.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Meghalaya, India"
@@ -40,7 +40,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_42199",
   "gbl_mdModified_dt": "2018-06-19T16:03:45Z",
   "id": "nyu-2451-42199",
   "nyu_addl_dspace_s": "43303",

--- a/metadata-aardvark/Datasets/nyu-2451-42202.json
+++ b/metadata-aardvark/Datasets/nyu-2451-42202.json
@@ -28,7 +28,7 @@
   ],
   "dct_issued_s": "3/12/2018",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42202\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85099/nyu_2451_42202.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/42202\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/85099/nyu_2451_42202.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/85081/nyu_2451_42185_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Nagaland, India"
@@ -40,7 +40,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_42202",
   "gbl_mdModified_dt": "2018-06-19T16:03:45Z",
   "id": "nyu-2451-42202",
   "nyu_addl_dspace_s": "43306",

--- a/metadata-aardvark/Datasets/nyu-2451-63574.json
+++ b/metadata-aardvark/Datasets/nyu-2451-63574.json
@@ -32,7 +32,7 @@
   ],
   "dct_issued_s": "7/24/2020",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/63574\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/128820/nyu_2451_63574.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/128815/nyu_2451_63574_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/63574\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/128820/nyu_2451_63574.zip\",  \"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/128815/nyu_2451_63574_doc.zip\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "Egypt"
@@ -44,7 +44,6 @@
   "gbl_resourceType_sm": [
     "Polygon data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_63574",
   "gbl_mdModified_dt": "2021-12-20T10:29:38Z",
   "id": "nyu-2451-63574",
   "nyu_addl_dspace_s": "64784",


### PR DESCRIPTION
There were a number of ESRI Geodatabases records that had WXS Identifiers and/or WMS/WFS references. GeoServer doesn't support ESRI Geodatabases.

This PR removes the invalid entries from those records.