### PR TITLE
GeoServer does not support LAS

### DIFF
--- a/metadata-aardvark/Datasets/nyu-2451-38616.json
+++ b/metadata-aardvark/Datasets/nyu-2451-38616.json
@@ -8,7 +8,7 @@
   ],
   "dct_accessRights_s": "Public",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38616\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79925/nyu_2451_38616_fwf_las_T_316500_235500.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38616\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79925/nyu_2451_38616_fwf_las_T_316500_235500.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
   "gbl_wxsIdentifier_s": "sdr:nyu_2451_38616",
   "id": "nyu-2451-38616",
   "gbl_resourceType_sm": [

--- a/metadata-aardvark/Datasets/nyu-2451-38622.json
+++ b/metadata-aardvark/Datasets/nyu-2451-38622.json
@@ -8,8 +8,7 @@
   ],
   "dct_accessRights_s": "Public",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38622\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79940/nyu_2451_38622_fwf_las_T_317500_233000.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_38622",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38622\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79940/nyu_2451_38622_fwf_las_T_317500_233000.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
   "id": "nyu-2451-38622",
   "gbl_resourceType_sm": [
     "Multi-spectral data"

--- a/metadata-aardvark/Datasets/nyu-2451-38623.json
+++ b/metadata-aardvark/Datasets/nyu-2451-38623.json
@@ -8,8 +8,7 @@
   ],
   "dct_accessRights_s": "Public",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38623\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79941/nyu_2451_38623_fwf_las_T_317500_233500.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_38623",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38623\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79941/nyu_2451_38623_fwf_las_T_317500_233500.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
   "id": "nyu-2451-38623",
   "gbl_resourceType_sm": [
     "Multi-spectral data"

--- a/metadata-aardvark/Datasets/nyu-2451-38624.json
+++ b/metadata-aardvark/Datasets/nyu-2451-38624.json
@@ -8,8 +8,7 @@
   ],
   "dct_accessRights_s": "Public",
   "schema_provider_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38624\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79943/nyu_2451_38624_fwf_las_T_317500_234000.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_38624",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38624\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/79943/nyu_2451_38624_fwf_las_T_317500_234000.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/81335/nyu_2451_38684_doc.zip\"}",
   "id": "nyu-2451-38624",
   "gbl_resourceType_sm": [
     "Multi-spectral data"


### PR DESCRIPTION
Removes WXS, WFS and WMS entries and references for LAS files. Geoserver does not support LAS files.