### PR TITLE
GeoServer does not support SQLite Databases

### DIFF
--- a/metadata-aardvark/Datasets/nyu-2451-34679.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34679.json
@@ -30,7 +30,7 @@
   ],
   "dct_issued_s": "5/10/2019",
   "schema_provider_s": "Baruch CUNY",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34679\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/89073/nyu_2451_34679.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/89074/nyu_2451_34679_doc.zip\",\"http://www.isotc211.org/schemas/2005/gmd\":\"http://faculty.baruch.cuny.edu/geoportal/metadata/nyc_real_estate/NYC_RealEstate_Sales.xml\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34679\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/89073/nyu_2451_34679.zip\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/89074/nyu_2451_34679_doc.zip\",\"http://www.isotc211.org/schemas/2005/gmd\":\"http://faculty.baruch.cuny.edu/geoportal/metadata/nyc_real_estate/NYC_RealEstate_Sales.xml\"}",
   "dct_source_sm": [],
   "dct_spatial_sm": [
     "New York City, New York, United States",
@@ -53,7 +53,6 @@
   "gbl_resourceType_sm": [
     "Multi-spectral data"
   ],
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34679",
   "gbl_mdModified_dt": "2020-01-06T14:38:43Z",
   "id": "nyu-2451-34679",
   "nyu_addl_dspace_s": "35621",

--- a/metadata-aardvark/Datasets/nyu-2451-34763.json
+++ b/metadata-aardvark/Datasets/nyu-2451-34763.json
@@ -1,6 +1,5 @@
 {
   "id": "nyu-2451-34763",
-  "gbl_wxsIdentifier_s": "sdr:nyu_2451_34763",
   "schema_provider_s": "Baruch CUNY",
   "gbl_resourceClass_sm": [
     "Datasets"
@@ -36,7 +35,7 @@
   "gbl_mdModified_dt": "2016-06-27T14:58:39Z",
   "nyu_addl_dspace_s": "35711",
   "gbl_mdVersion_s": "Aardvark",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34763\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/34763\"}",
   "dct_description_sm": [
     "The layers in this Sqlite Geodatabase were created from the GTFS data feeds from the Metropolitan Transportation Authority (MTA) to represent major routes and stops for buses and trains throughout New York City. A python script was written to take the data files as input and plot and save them in the local state plane coordinate reference system. This dataset is intended for researchers, policy makers, students, and educators for basic geographic analysis and mapping purposes. It was created by the GIS Lab at the Newman Library at Baruch College CUNY as part of the NYC Mass Transit Spatial Layers series, so that members of the public could have access to well-documented and readily-usable GIS layers of NYC mass transit features."
   ],


### PR DESCRIPTION
Removes WXS, WMF and WMS references from SQLite Database records. GeoServer does not support SQLite Databases.